### PR TITLE
Fix usage date shift and isolate form messages

### DIFF
--- a/backend/routes/inventoryRoutes.js
+++ b/backend/routes/inventoryRoutes.js
@@ -124,6 +124,14 @@ router.post("/usage", async (req, res) => {
       });
     }
 
+    const normalizedUsageDate = String(usageDate).trim().split("T")[0];
+
+    if (!/^\d{4}-\d{2}-\d{2}$/.test(normalizedUsageDate)) {
+      return res.status(400).json({
+        message: "Usage date must be in YYYY-MM-DD format"
+      });
+    }
+
     const item = await Inventory.findById(itemId);
 
     if (!item) {
@@ -146,17 +154,15 @@ router.post("/usage", async (req, res) => {
     const updatedItem = await item.save();
 
     const newUsageLog = new UsageLog({
-  itemId: updatedItem._id,
-  itemName: updatedItem.itemName,
-  quantityUsed: quantityUsed,
-  usageDate: new Date(usageDate), // fixed date format
-  remainingStock: updatedItem.currentStock,
-  riskLevel: updatedItem.riskLevel,
-  createdAt: new Date() // added timestamp
-});
+      itemId: updatedItem._id,
+      itemName: updatedItem.itemName,
+      quantityUsed,
+      usageDate: normalizedUsageDate,
+      remainingStock: updatedItem.currentStock,
+      riskLevel: updatedItem.riskLevel
+    });
 
     const savedLog = await newUsageLog.save();
-    console.log("Usage log created successfully:", savedLog);
 
     res.json({
       message: "Inventory usage logged successfully",

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -9,8 +9,16 @@ function App() {
   const [quantityUsed, setQuantityUsed] = useState("");
   const [usageDate, setUsageDate] = useState(new Date().toISOString().split("T")[0]);
   const [usageLogs, setUsageLogs] = useState([]);
-  const [message, setMessage] = useState("");
-  const [messageType, setMessageType] = useState("");
+
+  const [globalMessage, setGlobalMessage] = useState("");
+  const [globalMessageType, setGlobalMessageType] = useState("");
+
+  const [addItemMessage, setAddItemMessage] = useState("");
+  const [addItemMessageType, setAddItemMessageType] = useState("");
+
+  const [usageMessage, setUsageMessage] = useState("");
+  const [usageMessageType, setUsageMessageType] = useState("");
+
   const [loading, setLoading] = useState(true);
 
   const [newItemName, setNewItemName] = useState("");
@@ -21,14 +29,34 @@ function App() {
   const API_BASE_URL = import.meta.env.VITE_API_URL || "http://localhost:5000";
   const API_URL = `${API_BASE_URL}/api/inventory`;
 
-  const showMessage = (text, type = "error") => {
-    setMessage(text);
-    setMessageType(type);
+  const showGlobalMessage = (text, type = "error") => {
+    setGlobalMessage(text);
+    setGlobalMessageType(type);
   };
 
-  const clearMessage = () => {
-    setMessage("");
-    setMessageType("");
+  const clearGlobalMessage = () => {
+    setGlobalMessage("");
+    setGlobalMessageType("");
+  };
+
+  const showAddItemMessage = (text, type = "error") => {
+    setAddItemMessage(text);
+    setAddItemMessageType(type);
+  };
+
+  const clearAddItemMessage = () => {
+    setAddItemMessage("");
+    setAddItemMessageType("");
+  };
+
+  const showUsageMessage = (text, type = "error") => {
+    setUsageMessage(text);
+    setUsageMessageType(type);
+  };
+
+  const clearUsageMessage = () => {
+    setUsageMessage("");
+    setUsageMessageType("");
   };
 
   const getRiskDisplayName = (riskLevel) => {
@@ -41,6 +69,23 @@ function App() {
     if (riskLevel === "High") return "high";
     if (riskLevel === "Medium") return "medium";
     return "low";
+  };
+
+  const formatUsageDate = (value) => {
+    if (!value) return "";
+
+    if (typeof value === "string" && /^\d{4}-\d{2}-\d{2}$/.test(value)) {
+      const [year, month, day] = value.split("-");
+      return `${year}/${Number(month)}/${Number(day)}`;
+    }
+
+    const parsed = new Date(value);
+
+    if (Number.isNaN(parsed.getTime())) {
+      return String(value);
+    }
+
+    return `${parsed.getFullYear()}/${parsed.getMonth() + 1}/${parsed.getDate()}`;
   };
 
   const fetchInventory = async () => {
@@ -63,7 +108,7 @@ function App() {
         setSelectedItemId("");
       }
     } catch (error) {
-      showMessage("Failed to load inventory data.", "error");
+      showGlobalMessage("Failed to load inventory data.", "error");
     }
   };
 
@@ -78,7 +123,7 @@ function App() {
 
       setUsageLogs(data);
     } catch (error) {
-      showMessage("Failed to load usage logs.", "error");
+      showGlobalMessage("Failed to load usage logs.", "error");
     }
   };
 
@@ -100,36 +145,56 @@ function App() {
   }, []);
 
   useEffect(() => {
-    if (!message) return;
+    if (!globalMessage) return;
 
     const timer = setTimeout(() => {
-      clearMessage();
+      clearGlobalMessage();
     }, 3000);
 
     return () => clearTimeout(timer);
-  }, [message]);
+  }, [globalMessage]);
+
+  useEffect(() => {
+    if (!addItemMessage) return;
+
+    const timer = setTimeout(() => {
+      clearAddItemMessage();
+    }, 3000);
+
+    return () => clearTimeout(timer);
+  }, [addItemMessage]);
+
+  useEffect(() => {
+    if (!usageMessage) return;
+
+    const timer = setTimeout(() => {
+      clearUsageMessage();
+    }, 3000);
+
+    return () => clearTimeout(timer);
+  }, [usageMessage]);
 
   const handleUsageSubmit = async (e) => {
     e.preventDefault();
-    clearMessage();
+    clearUsageMessage();
 
     const usedQty = Number(quantityUsed);
 
     if (!selectedItemId) {
       alert("Please choose an item before submitting.");
-      showMessage("Please choose an item before submitting.", "error");
+      showUsageMessage("Please choose an item before submitting.", "error");
       return;
     }
 
     if (!usageDate || !String(usageDate).trim()) {
       alert("Please choose the date of use.");
-      showMessage("Please choose the date of use.", "error");
+      showUsageMessage("Please choose the date of use.", "error");
       return;
     }
 
     if (quantityUsed === "" || Number.isNaN(usedQty) || usedQty <= 0) {
       alert("Please enter a quantity greater than 0.");
-      showMessage("Please enter a quantity greater than 0.", "error");
+      showUsageMessage("Please enter a quantity greater than 0.", "error");
       return;
     }
 
@@ -150,24 +215,24 @@ function App() {
 
       if (!response.ok) {
         alert(data.message || "Failed to update inventory usage.");
-        showMessage(data.message || "Failed to update inventory usage.", "error");
+        showUsageMessage(data.message || "Failed to update inventory usage.", "error");
         return;
       }
 
-      showMessage(data.message || "Usage recorded successfully.", "success");
+      showUsageMessage(data.message || "Usage recorded successfully.", "success");
       setQuantityUsed("");
       setUsageDate(new Date().toISOString().split("T")[0]);
 
       await Promise.all([fetchInventory(), fetchUsageLogs()]);
     } catch (error) {
       alert("Something went wrong while saving the usage entry.");
-      showMessage("Something went wrong while saving the usage entry.", "error");
+      showUsageMessage("Something went wrong while saving the usage entry.", "error");
     }
   };
 
   const handleAddItem = async (e) => {
     e.preventDefault();
-    clearMessage();
+    clearAddItemMessage();
 
     const trimmedItemName = newItemName.trim();
     const stockValue = Number(newStock);
@@ -175,25 +240,25 @@ function App() {
 
     if (newItemName === "" || trimmedItemName === "") {
       alert("Please enter an item name.");
-      showMessage("Please enter an item name.", "error");
+      showAddItemMessage("Please enter an item name.", "error");
       return;
     }
 
     if (trimmedItemName.length < 2) {
       alert("Item name must be at least 2 characters long.");
-      showMessage("Item name must be at least 2 characters long.", "error");
+      showAddItemMessage("Item name must be at least 2 characters long.", "error");
       return;
     }
 
     if (newStock === "" || Number.isNaN(stockValue) || stockValue < 0) {
       alert("Current stock must be a valid number greater than or equal to 0.");
-      showMessage("Current stock must be a valid number greater than or equal to 0.", "error");
+      showAddItemMessage("Current stock must be a valid number greater than or equal to 0.", "error");
       return;
     }
 
     if (newThreshold === "" || Number.isNaN(thresholdValue) || thresholdValue < 1) {
       alert("Reorder threshold must be a valid number greater than or equal to 1.");
-      showMessage("Reorder threshold must be a valid number greater than or equal to 1.", "error");
+      showAddItemMessage("Reorder threshold must be a valid number greater than or equal to 1.", "error");
       return;
     }
 
@@ -214,11 +279,11 @@ function App() {
 
       if (!response.ok) {
         alert(data.message || "Failed to add inventory item.");
-        showMessage(data.message || "Failed to add inventory item.", "error");
+        showAddItemMessage(data.message || "Failed to add inventory item.", "error");
         return;
       }
 
-      showMessage(data.message || "Inventory item added successfully.", "success");
+      showAddItemMessage(data.message || "Inventory item added successfully.", "success");
       setNewItemName("");
       setNewStock("");
       setNewThreshold("");
@@ -226,7 +291,7 @@ function App() {
       await fetchInventory();
     } catch (error) {
       alert("Server error while adding item.");
-      showMessage("Server error while adding item.", "error");
+      showAddItemMessage("Server error while adding item.", "error");
     }
   };
 
@@ -273,7 +338,7 @@ function App() {
           </div>
         </section>
 
-       <ConfirmationBanner message={message} type={messageType} />
+        <ConfirmationBanner message={globalMessage} type={globalMessageType} />
 
         <section className="stats-grid">
           <div className="stat-card">
@@ -406,14 +471,14 @@ function App() {
                   value={newItemName}
                   onChange={(e) => {
                     setNewItemName(e.target.value);
-                    if (messageType === "error") {
-                      clearMessage();
+                    if (addItemMessageType === "error") {
+                      clearAddItemMessage();
                     }
                   }}
                   onBlur={() => {
                     if (!newItemName.trim()) {
                       alert("Please enter an item name.");
-                      showMessage("Please enter an item name.", "error");
+                      showAddItemMessage("Please enter an item name.", "error");
                     }
                   }}
                   placeholder="Enter item name"
@@ -445,7 +510,7 @@ function App() {
               <button type="submit">Add Item</button>
             </form>
 
-           <ConfirmationBanner message={message} type={messageType} />
+            <ConfirmationBanner message={addItemMessage} type={addItemMessageType} />
           </div>
 
           <div className="panel glass-panel">
@@ -493,7 +558,7 @@ function App() {
               <button type="submit">Submit Usage</button>
             </form>
 
-            {message && <div className={`status-message ${messageType}`}>{message}</div>}
+            <ConfirmationBanner message={usageMessage} type={usageMessageType} />
           </div>
         </section>
 
@@ -628,7 +693,7 @@ function App() {
                     <tr key={log._id}>
                       <td>{log.itemName}</td>
                       <td>{log.quantityUsed}</td>
-                      <td>{new Date(log.usageDate).toLocaleDateString()}</td>
+                      <td>{formatUsageDate(log.usageDate)}</td>
                       <td>
                         <span className={`risk-badge ${getRiskDisplayClass(log.riskLevel)}`}>
                           {getRiskDisplayName(log.riskLevel)}


### PR DESCRIPTION
## Summary
This PR fixes two issues in the inventory usage workflow:

1. The usage date in the log could display one day earlier than the selected form date.
2. Validation/error messages from the usage form and add-item form were showing together instead of staying in their own panels.

## Changes made
- Updated inventory usage date handling to keep the submitted date consistent in the usage log
- Isolated message state for:
  - Add Inventory Item
  - Log Inventory Usage
  - Global/system messages
- Updated usage log date rendering to avoid timezone-related display shift

## Result
- The selected usage date now stays consistent in the log
- Error/success messages now appear only in the correct form section
- Existing inventory update, stock deduction, log creation, and validation behavior remain unchanged

## Testing
Tested the following scenarios:
- Valid inventory usage submission
- Empty quantity validation
- Quantity set to 0
- Quantity exceeding current stock
- Add Inventory Item validation still works correctly
- Usage log date displays correctly after submission